### PR TITLE
Floor seconds when rendering with minutes

### DIFF
--- a/easypy/units.py
+++ b/easypy/units.py
@@ -1,7 +1,8 @@
-import re
 from itertools import repeat
-import random
+from math import floor
 import numbers
+import random
+import re
 from easypy.exceptions import TException
 
 
@@ -323,6 +324,7 @@ class Duration(float):
         ss = float(self)
         if unit not in ("ms", "s"):
             mm, ss = divmod(ss, 60)
+            ss = floor(ss)
         if unit != "m":
             hh, mm = divmod(mm, 60)
         if unit != "h":


### PR DESCRIPTION
A duration of 119.5 seconds will now render as 1:59m instead of 1:60m