### PR TITLE
logging/indented - handle percent with no args

### DIFF
--- a/easypy/logging/__init__.py
+++ b/easypy/logging/__init__.py
@@ -145,10 +145,10 @@ class ContextableLoggerMixin(object):
         from easypy.timing import timing as timing_context
 
         level = if_auto(level, G.NOTICE)
-        if header:
-            header = (header % args) if args else header
-        else:
+        if not header:
             header = ""
+        elif args:
+            header = (header % args)
         self.log(level, "WHITE@[%s]@" % header, extra=dict(decoration=G.graphics.INDENT_OPEN))
         with ExitStack() as stack:
             stack.enter_context(THREAD_LOGGING_CONTEXT(indentation=1))

--- a/easypy/logging/__init__.py
+++ b/easypy/logging/__init__.py
@@ -145,7 +145,10 @@ class ContextableLoggerMixin(object):
         from easypy.timing import timing as timing_context
 
         level = if_auto(level, G.NOTICE)
-        header = (header % args) if header else ""
+        if header:
+            header = (header % args) if args else header
+        else:
+            header = ""
         self.log(level, "WHITE@[%s]@" % header, extra=dict(decoration=G.graphics.INDENT_OPEN))
         with ExitStack() as stack:
             stack.enter_context(THREAD_LOGGING_CONTEXT(indentation=1))


### PR DESCRIPTION
Fix `indented` used with header that contains %x string and no args passed.