### PR TITLE
concurrency: coalesce duplicated tracebacks multiexception

### DIFF
--- a/easypy/collections.py
+++ b/easypy/collections.py
@@ -34,8 +34,8 @@ if sys.version_info[:2] >= (3, 5):
 
 
 def _format_predicate(pred):
-    args = inspect.formatargspec(*inspect.getargspec(pred))
-    return "<lambda>" if pred.__name__ == "<lambda>" else "{pred.__name__}{args}".format(**locals())
+    signature = inspect.signature(pred)
+    return "<lambda>" if pred.__name__ == "<lambda>" else f"{pred.__name__}{signature}"
 
 
 def _format_filter_string(preds, filters):

--- a/easypy/concurrency.py
+++ b/easypy/concurrency.py
@@ -68,7 +68,7 @@ from contextlib import contextmanager, ExitStack
 from functools import partial, wraps
 from importlib import import_module
 from itertools import chain, count
-from traceback import format_tb
+from traceback import format_tb, extract_tb
 import inspect
 import logging
 import threading
@@ -233,6 +233,7 @@ class MultiException(PException, metaclass=MultiExceptionMeta):
     CORE_COMMON_TYPE = BaseException  # the fallback core common type
     DEPTH = 0
     template = "{0.common_type.__qualname__} raised from concurrent invocation (x{0.count}/{0.invocations_count})"
+    tb_coalesce_template = "  See exception ({}) for traceback"
 
     def __reduce__(self):
         return (MultiException, (self.exceptions, [PickledFuture(ctx=f.ctx, funcname=f.funcname) for f in self.futures]))
@@ -274,6 +275,9 @@ class MultiException(PException, metaclass=MultiExceptionMeta):
         return colorize("\n" + text)
 
     def _get_buffer(self, **kw):
+        exc_num_prefix = kw.setdefault('exc_num_prefix', '')
+        unique_tbs_to_exc_num = kw.setdefault("unique_tbs_to_exc_num", {})
+
         if kw.get("color", True):
             normalize_color = lambda x: x
         else:
@@ -313,19 +317,36 @@ class MultiException(PException, metaclass=MultiExceptionMeta):
 
         add_details(self)
 
-        for exc in self.actual:
-            with buff.indent("{.__class__.__qualname__}", exc):
+        should_coalesce_duplicated_tbs = False if (
+                os.getenv('EASYPY_MULTIEXCEPTION_COALESCE_DUPLICATED_TBS','') in ['false']) else True
+        for exc_num, exc in enumerate(self.actual, 1):
+            show_traceback = hasattr(exc, "__traceback__") and getattr(exc, 'traceback', None) is not False
+            full_exc_num_with_same_tb = None
+            full_exc_num = f"{exc_num_prefix}{exc_num}"
+
+            if should_coalesce_duplicated_tbs and show_traceback:
+                if tb := tuple((frame.filename, frame.lineno) for frame in extract_tb(exc.__traceback__)):
+                    if tb in unique_tbs_to_exc_num:
+                        full_exc_num_with_same_tb = unique_tbs_to_exc_num[tb]
+                    else:
+                        unique_tbs_to_exc_num[tb] = full_exc_num
+
+
+            with buff.indent(f"{{.__class__.__qualname__}} ({full_exc_num})", exc):
                 if isinstance(exc, MultiException):
+                    kw['exc_num_prefix'] = f"{full_exc_num}."
                     buff.extend(exc._get_buffer(**kw))
+                    kw['exc_num_prefix'] = exc_num_prefix
                 elif callable(getattr(exc, "render", None)):
                     buff.write(exc.render(**kw))
                 else:
                     buff.write("{}", exc)
                     add_details(exc)
-                if hasattr(exc, "__traceback__"):
-                    show_traceback = getattr(exc, 'traceback', None)
-                    if show_traceback is not False:
-                        buff.write("Traceback:")
+                if show_traceback:
+                    buff.write("Traceback:")
+                    if full_exc_num_with_same_tb:
+                        buff.write(self.tb_coalesce_template.format(full_exc_num_with_same_tb))
+                    else:
                         for line in format_tb(exc.__traceback__):
                             buff.write(traceback_fmt, line.rstrip())
 


### PR DESCRIPTION
Allowing: 

- Coalesce duplicated tracebacks inside a MultiException

- Numbering excs inside a MultiException
