### PR TITLE
threadtree: ensure frame snapshot registry cleanup after thread exit

### DIFF
--- a/easypy/threadtree.py
+++ b/easypy/threadtree.py
@@ -97,6 +97,9 @@ def start_new_thread(target, *args, **kwargs):
         try:
             return target(*args, **kwargs)
         finally:
+            # remove the snapshot connecting parent → this thread
+            _FRAME_SNAPSHOTS_REGISTRY.pop((parent_thread.uuid, thread.uuid), None)
+
             IDENT_TO_UUID.pop(thread.ident)
 
     return _orig_start_new_thread(wrapper, *args, **kwargs)

--- a/tests/test_threadtree.py
+++ b/tests/test_threadtree.py
@@ -1,6 +1,6 @@
 import threading
 
-from easypy.threadtree import walk_frames
+from easypy.threadtree import walk_frames, _FRAME_SNAPSHOTS_REGISTRY
 
 
 def collect_frames():
@@ -53,3 +53,4 @@ def test_walk_frames():
     ]
     actual = [frame.f_code.co_name for frame in frames]
     assert actual == expected
+    assert len(_FRAME_SNAPSHOTS_REGISTRY) == 0, "Frame snapshots registry should be empty after threads have finished"


### PR DESCRIPTION
previously, frame snapshots connecting parent and child threads were not fully removed when threads exited, leading to potential memory leaks and incorrect state tracking. this change ensures all relevant snapshots are cleaned up, including cases where a thread acts as a parent for others. the test verifies that the registry is empty after threads finish